### PR TITLE
feat: Macenko fast GPU path

### DIFF
--- a/benchmarks/pareto_time_mae.py
+++ b/benchmarks/pareto_time_mae.py
@@ -46,30 +46,28 @@ from stainx import HistogramMatching, Macenko, Reinhard
 from stainx.backends.torch_cuda_backend import CUDA_AVAILABLE
 
 BATCH, H, W = 128, 256, 256
-WARMUP, RUNS = 30, 100
+WARMUP, RUNS = 10, 300
 ROOT = Path(__file__).resolve().parents[1]
 DATA = ROOT / "examples" / "data"
 OUT = Path(__file__).resolve().parent / "logs" / "pareto_time_mae.png"
 
 METHODS = ("Macenko", "Reinhard", "HistogramMatching")
 DEVICE_MARKER = {"CPU": "o", "GPU": "*"}
-# Color encodes package. #9b2335 dominates for stainx; peers get distinct accents.
+# High-contrast categorical palette. Seed purples/pinks kept for stainx + peers;
+# remaining packages use distinct accents so markers stay separable on white.
 PACKAGE_COLOR = {
-    "torchstain": "#5c7a8a",
-    "torchstain[modified]": "#7a9aab",
-    "stainx[torch]": "#9b2335",
-    "stainx[torch_cuda]": "#6e1826",
-    "slideflow": "#d4a017",
-    "slideflow[fast]": "#b8860b",
-    "color-matcher": "#2f6f4e",
-    "tiatoolbox": "#6b4c9a",
-    "torch-staintools": "#c45c26",
-    "wsi-normalizer": "#2a6f97",
-    "colortrans": "#8b5a2b",
-    "color_transfer": "#4a6741",
+    "stainx": "#412b73",  # deep purple (dominant)
+    "torchstain": "#7D4493",  # mid purple (seed)
+    "slideflow": "#E69F00",  # gold — strong contrast to purple
+    "torch-staintools": "#009E73",  # teal
+    "tiatoolbox": "#0072B2",  # blue
+    "wsi-normalizer": "#56B4E9",  # sky
+    "color-matcher": "#b166a6",  # magenta (seed)
+    "colortrans": "#D55E00",  # vermillion
+    "color_transfer": "#f196c1",  # pink (seed)
 }
 PACKAGE_COLOR_FALLBACK = "#555555"
-PARETO_COLOR = "#444444"
+PARETO_COLOR = "#333333"
 # MAE reference used for error (build_baselines). Omit pure reference libs from the
 # scatter; keep torchstain plotted so the package is visible (Macenko MAE≈0 by construction).
 MAE_BASELINE_PACKAGE = {"Macenko": "torchstain", "Reinhard": "StainTools", "HistogramMatching": "skimage"}
@@ -230,14 +228,7 @@ def collect_results(ref: torch.Tensor, src: torch.Tensor, baselines: dict[str, t
 
     add("Reinhard", "colortrans", cpu, lambda: [colortrans.transfer_reinhard(src_nhwc[i], ref_hwc) for i in range(BATCH)])
     ref_bgr = cv2.cvtColor(ref_hwc, cv2.COLOR_RGB2BGR)
-    add(
-        "Reinhard",
-        "color_transfer",
-        cpu,
-        lambda: [
-            cv2.cvtColor(pyimagesearch_color_transfer(ref_bgr, cv2.cvtColor(src_nhwc[i], cv2.COLOR_RGB2BGR)), cv2.COLOR_BGR2RGB) for i in range(BATCH)
-        ],
-    )
+    add("Reinhard", "color_transfer", cpu, lambda: [cv2.cvtColor(pyimagesearch_color_transfer(ref_bgr, cv2.cvtColor(src_nhwc[i], cv2.COLOR_RGB2BGR)), cv2.COLOR_BGR2RGB) for i in range(BATCH)])
 
     # tiatoolbox (StainTools-derived Reinhard / Macenko)
     from tiatoolbox.tools import stainnorm
@@ -274,10 +265,8 @@ def collect_results(ref: torch.Tensor, src: torch.Tensor, baselines: dict[str, t
 
     # StainX (native batch; H2D outside timer)
     backends = [("torch", cpu)]
-    if cuda is not None:
-        backends.append(("torch", cuda))
-        if CUDA_AVAILABLE:
-            backends.append(("torch_cuda", cuda))
+    if cuda is not None and CUDA_AVAILABLE:
+        backends.append(("torch_cuda", cuda))
 
     for method, cls, kwargs in (("Macenko", Macenko, {}), ("Reinhard", Reinhard, {}), ("HistogramMatching", HistogramMatching, {"channel_axis": 1})):
         for backend, dev in backends:
@@ -285,6 +274,13 @@ def collect_results(ref: torch.Tensor, src: torch.Tensor, baselines: dict[str, t
             n.fit(ref.to(dev))
             x = src.to(dev)
             add(method, f"stainx[{backend}]", dev, lambda n=n, x=x: n.transform(x))
+
+    # StainX Macenko fast precision (fp32 cov/eigh + fp16 pixels — no fp64)
+    if cuda is not None and CUDA_AVAILABLE:
+        n_fast = Macenko(device=cuda, backend="torch_cuda", precision="fast")
+        n_fast.fit(ref.to(cuda))
+        x_fast = src.to(cuda)
+        add("Macenko", "stainx[torch_cuda_fast]", cuda, lambda n=n_fast, x=x_fast: n.transform(x))
 
     # Slideflow
     devices = [cpu] + ([cuda] if cuda is not None else [])
@@ -309,8 +305,20 @@ def _panel_label(package: str, method: str) -> str:
     return package
 
 
+def _package_family(package: str) -> str:
+    """Collapse backends/variants to one legend/color family (e.g. stainx[*] → stainx)."""
+    if package.startswith("stainx"):
+        return "stainx"
+    if package.startswith("slideflow"):
+        return "slideflow"
+    if package.startswith("torchstain"):
+        return "torchstain"
+    return package
+
+
 def _package_color(package: str, method: str) -> str:
-    return PACKAGE_COLOR.get(_panel_label(package, method), PACKAGE_COLOR_FALLBACK)
+    _ = method
+    return PACKAGE_COLOR.get(_package_family(package), PACKAGE_COLOR_FALLBACK)
 
 
 def plot(results: list[dict], path: Path, mae_max: float = MAE_MAX) -> None:
@@ -427,13 +435,30 @@ def plot(results: list[dict], path: Path, mae_max: float = MAE_MAX) -> None:
         ax.tick_params(axis="x", which="major", labelrotation=35)
         ax.tick_params(axis="both", which="minor", length=0)
 
-    # Shared legend on leftmost panel: device shapes + reference lines.
-    axes[0].scatter([], [], marker="o", c="#666666", s=50, label="CPU", edgecolors="black", linewidths=0.7, alpha=0.9)
-    axes[0].scatter([], [], marker="*", c="#666666", s=100, label="GPU", edgecolors="black", linewidths=0.7, alpha=0.9)
-    axes[0].plot([], [], "--", color=PARETO_COLOR, linewidth=1.3, label="Pareto front")
-    axes[0].plot([], [], ":", color="#555555", linewidth=1.4, label=f"Max. mean abs. error ({mae_max:.0f})")
-    leg = axes[0].legend(loc="upper left", frameon=True, fancybox=False, facecolor="white", framealpha=0.95, edgecolor="#cccccc", fontsize=6.5, borderpad=0.35, labelspacing=0.3, handletextpad=0.35)
-    leg.get_frame().set_linewidth(0.6)
+    # Two legends on the rightmost panel: package colors (squares) above; device/lines below.
+    # Pass explicit handles so the device legend does not also pick up package artists.
+    ax_leg = axes[-1]
+    packages_in_plot: list[str] = []
+    for p in results:
+        fam = _package_family(p["package"])
+        if fam not in packages_in_plot:
+            packages_in_plot.append(fam)
+
+    pkg_handles = [ax_leg.scatter([], [], marker="s", c=PACKAGE_COLOR.get(lab, PACKAGE_COLOR_FALLBACK), s=45, edgecolors="black", linewidths=0.6, alpha=0.9) for lab in packages_in_plot]
+    leg_pkg = ax_leg.legend(
+        handles=pkg_handles, labels=packages_in_plot, loc="lower right", bbox_to_anchor=(1.0, 0.175), ncol=2, columnspacing=0.8, frameon=True, fancybox=False, facecolor="white", framealpha=0.95, edgecolor="#cccccc", fontsize=6, borderpad=0.35, labelspacing=0.25, handletextpad=0.35, title="Package", title_fontsize=6.5
+    )
+    leg_pkg.get_frame().set_linewidth(0.6)
+    ax_leg.add_artist(leg_pkg)
+
+    h_cpu = ax_leg.scatter([], [], marker="o", c="#666666", s=50, edgecolors="black", linewidths=0.7, alpha=0.9)
+    h_gpu = ax_leg.scatter([], [], marker="*", c="#666666", s=100, edgecolors="black", linewidths=0.7, alpha=0.9)
+    h_pareto = ax_leg.plot([], [], "--", color=PARETO_COLOR, linewidth=1.3)[0]
+    h_max = ax_leg.plot([], [], ":", color="#555555", linewidth=1.4)[0]
+    leg_dev = ax_leg.legend(
+        handles=[h_cpu, h_gpu, h_pareto, h_max], labels=["CPU", "GPU", "Pareto front", f"Max. mean abs. error ({mae_max:.0f})"], loc="lower right", frameon=True, fancybox=False, facecolor="white", framealpha=0.95, edgecolor="#cccccc", fontsize=6.5, borderpad=0.35, labelspacing=0.3, handletextpad=0.35
+    )
+    leg_dev.get_frame().set_linewidth(0.6)
 
     axes[0].set_ylabel("Throughput (img/s)", fontsize=8, labelpad=2)
 

--- a/src/stainx/backends/torch_cuda_backend.py
+++ b/src/stainx/backends/torch_cuda_backend.py
@@ -97,12 +97,35 @@ class ReinhardCUDA(TorchCUDABackendBase):
 
 
 class MacenkoCUDA(TorchCUDABackendBase):
+    """Macenko CUDA backend.
+
+    Parameters
+    ----------
+    device : str or torch.device, optional
+        CUDA device to use.
+    precision : str, optional
+        Numerical precision mode. ``"stable"`` (default) uses the current
+        fp64-covariance + fp32-pixel path. ``"fast"`` uses fp32 cov/eigh
+        + fp16 for large pixel tensors (projection GEMM, phi sort,
+        reconstruct matmul) while keeping the 2x2 solve at fp32.
+        Both modes pass the same correctness suite vs torchstain.
+    """
+
+    def __init__(self, device: str | torch.device | None = None, precision: str = "stable"):
+        super().__init__(device)
+        if precision not in ("stable", "fast"):
+            raise ValueError(f"precision must be 'stable' or 'fast', got {precision!r}")
+        self._precision = precision
+
     def transform(self, images: torch.Tensor, stain_matrix: torch.Tensor, target_max_conc: torch.Tensor) -> torch.Tensor:
         images = images.to(self.device)
         stain_matrix = stain_matrix.to(self.device)
         target_max_conc = target_max_conc.to(self.device)
 
+        if self._precision == "fast":
+            if not hasattr(stainx_cuda_torch, "macenko_fast"):
+                raise RuntimeError("stainx_cuda_torch.macenko_fast is not available. The CUDA extension may not be built correctly.")
+            return stainx_cuda_torch.macenko_fast(images, stain_matrix, target_max_conc)
         if not hasattr(stainx_cuda_torch, "macenko"):
             raise RuntimeError("stainx_cuda_torch.macenko is not available. The CUDA extension may not be built correctly.")
-
         return stainx_cuda_torch.macenko(images, stain_matrix, target_max_conc)

--- a/src/stainx/normalizers/_template.py
+++ b/src/stainx/normalizers/_template.py
@@ -126,6 +126,7 @@ class NormalizerTemplate(StainNormalizerBase):
 
         torch_class = self._get_torch_class()
         kwargs = self._get_backend_kwargs()
+        kwargs.pop("precision", None)  # CUDA-only kwarg; not valid for torch backend
         return torch_class(device, **kwargs)
 
     def _get_backend_kwargs(self) -> dict:

--- a/src/stainx/normalizers/macenko.py
+++ b/src/stainx/normalizers/macenko.py
@@ -15,11 +15,33 @@ class Macenko(NormalizerTemplate):
     ``StainNormalizerTransform(method="macenko")`` defaults it to ``True`` for
     float ``[0, 1]`` training pipelines — prefer the transform there, or set the
     flag explicitly on this class.
+
+    Parameters
+    ----------
+    device : str or torch.device, optional
+        Device for computation.
+    backend : str, optional
+        Backend name (``"torch"`` or ``"torch_cuda"``).  Auto-selects when None.
+    normalize_to_0_1 : bool, optional
+        If True, divide output by 255.0 so the result is in [0, 1].
+    precision : str, optional
+        Numerical precision mode for the CUDA backend only.
+        ``"stable"`` (default) — fp64 cov/eigh + fp32 pixels.
+        ``"fast"`` — fp32 cov/eigh + fp16 large pixel tensors (projection
+        GEMM, phi sort, reconstruct matmul); 2x2 solve stays fp32.
+        Raises ``ValueError`` when set to ``"fast"`` with ``backend="torch"``.
     """
 
-    def __init__(self, device: Any | None = None, backend: str | None = None, normalize_to_0_1: bool = False):
+    def __init__(self, device: Any | None = None, backend: str | None = None, normalize_to_0_1: bool = False, precision: str = "stable"):
+        if precision not in ("stable", "fast"):
+            raise ValueError(f"precision must be 'stable' or 'fast', got {precision!r}")
+        self._precision = precision
         self.normalize_to_0_1 = normalize_to_0_1
         super().__init__(device=device, backend=backend)
+        # Validate precision/backend compatibility eagerly so the user gets
+        # a clear error at construction time, not lazily during transform().
+        if self._precision == "fast" and self.backend != "torch_cuda":
+            raise ValueError(f"precision='fast' requires backend='torch_cuda', but backend is '{self.backend}'. Either set backend='torch_cuda' or use precision='stable'.")
 
     def _init_algorithm_attributes(self):
         self._stain_matrix = None
@@ -40,6 +62,12 @@ class Macenko(NormalizerTemplate):
         backend = self._get_backend_for_computation_torch()
         self._stain_matrix, self._target_max_conc = backend.compute_reference_stain_matrix_torch(images)
         self._concentration_matrix = None
+
+    def _get_backend_kwargs(self) -> dict:
+        kwargs = super()._get_backend_kwargs()
+        if self._precision != "stable":
+            kwargs["precision"] = self._precision
+        return kwargs
 
     def _get_reference_params(self) -> tuple:
         return (self._stain_matrix, self._target_max_conc)

--- a/src/stainx_cuda_torch/__init__.py
+++ b/src/stainx_cuda_torch/__init__.py
@@ -31,19 +31,21 @@ elif torch_lib_path not in os.environ["LD_LIBRARY_PATH"]:
 FUNCTIONS_AVAILABLE = False
 histogram_matching = None
 macenko = None
+macenko_fast = None
 reinhard = None
 
 if importlib.util.find_spec(f"{__name__}.stainx_cuda_torch") is not None:
     try:
-        from .stainx_cuda_torch import histogram_matching, macenko, reinhard
+        from .stainx_cuda_torch import histogram_matching, macenko, macenko_fast, reinhard
 
-        if all(callable(f) for f in [histogram_matching, macenko, reinhard]):
+        if all(callable(f) for f in [histogram_matching, macenko, macenko_fast, reinhard]):
             FUNCTIONS_AVAILABLE = True
     except Exception:
         # Stale/incompatible .so (ABI mismatch) — fall back to Torch backend
         histogram_matching = None
         macenko = None
+        macenko_fast = None
         reinhard = None
         FUNCTIONS_AVAILABLE = False
 
-__all__ = ["FUNCTIONS_AVAILABLE", "histogram_matching", "macenko", "reinhard"]
+__all__ = ["FUNCTIONS_AVAILABLE", "histogram_matching", "macenko", "macenko_fast", "reinhard"]

--- a/src/stainx_cuda_torch/csrc/bindings.cpp
+++ b/src/stainx_cuda_torch/csrc/bindings.cpp
@@ -22,11 +22,14 @@ torch::Tensor reinhard_cuda(torch::Tensor input_images, torch::Tensor reference_
 
 torch::Tensor macenko_cuda(torch::Tensor input_images, torch::Tensor stain_matrix, torch::Tensor target_max_conc);
 
+torch::Tensor macenko_cuda_fast(torch::Tensor input_images, torch::Tensor stain_matrix, torch::Tensor target_max_conc);
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.doc() = "StainX CUDA backend for GPU-accelerated stain normalization (PyTorch interface)";
 
     // Bind CUDA implementations
     m.def("histogram_matching", &histogram_matching_cuda, "Histogram matching CUDA");
     m.def("reinhard", &reinhard_cuda, "Reinhard normalization CUDA");
-    m.def("macenko", &macenko_cuda, "Macenko normalization CUDA");
+    m.def("macenko", &macenko_cuda, "Macenko normalization CUDA (stable: fp64 cov + fp32 pixels)");
+    m.def("macenko_fast", &macenko_cuda_fast, "Macenko normalization CUDA (fast: fp32 cov/eigh + fp16 pixels)");
 }

--- a/src/stainx_cuda_torch/csrc/macenko.cu
+++ b/src/stainx_cuda_torch/csrc/macenko.cu
@@ -104,8 +104,21 @@ __device__ void analytic_eigh_sym3(const T A[3][3], T evecs2[3][2]) {
 
     T e_asc[3];  // eigenvalues ascending
     if (p1 <= T(1e-30)) {
-        // Already diagonal (or effectively zero off-diagonal).
-        e_asc[0] = e_asc[1] = e_asc[2] = q;
+        // Already diagonal (or effectively zero off-diagonal):
+        // eigenvalues are the diagonal entries, not the trace mean.
+        e_asc[0] = A[0][0];
+        e_asc[1] = A[1][1];
+        e_asc[2] = A[2][2];
+        // Insertion-sort ascending.
+        for (int i = 1; i < 3; ++i) {
+            const T key = e_asc[i];
+            int j = i - 1;
+            while (j >= 0 && e_asc[j] > key) {
+                e_asc[j + 1] = e_asc[j];
+                --j;
+            }
+            e_asc[j + 1] = key;
+        }
     } else {
         const T p2 = (A[0][0] - q) * (A[0][0] - q) + (A[1][1] - q) * (A[1][1] - q) + (A[2][2] - q) * (A[2][2] - q) + T(2.0) * p1;
         const T p  = sqrt(p2 / T(6.0));

--- a/src/stainx_cuda_torch/csrc/macenko.cu
+++ b/src/stainx_cuda_torch/csrc/macenko.cu
@@ -5,7 +5,7 @@
 // See the LICENSE file for details.
 
 /*
- * Macenko normalization for CUDA tensors — fully on-GPU implementation.
+ * Macenko normalization for CUDA tensors — fully on-GPU, two precision modes.
  *
  * Earlier versions offloaded the 3x3 OD covariance, its eigendecomposition and
  * the concentration least-squares to the CPU: CUDA float32 covariance reductions
@@ -13,23 +13,21 @@
  * torchstain was only reachable via LAPACK on the host. That host round-trip
  * forces a full device sync per image and dominates the runtime.
  *
- * This implementation keeps the covariance + eigh in double precision (the only
- * numerically sensitive part) and runs everything else in float32 for speed:
- *   - a custom per-image reduction kernel (macenko_cov_kernel) forms the filtered
- *     OD mean + covariance in fp64 using warp-level tree reduction (no atomicAdd);
- *   - a closed-form symmetric-3x3 eigensolver (analytic_eigh_sym3) replaces
- *     cuSOLVER/LAPACK eigh and matches torch.linalg.eigh to machine precision;
- *   - projection, angle percentiles, the H/E heuristic, the (H^T H) 2x2 normal
- *     equations for concentrations, and reconstruction are batched ATen ops in fp32.
+ * This implementation provides two selectable modes:
  *
- * fp64 on the 3x3 cov/eigh makes the stain-plane extraction robust to the flip
- * seen with fp32 reductions on near-degenerate spectra.  Once the plane is fixed,
- * fp32 downstream cannot change which plane we picked — it only computes
- * coordinates and reconstructs, with errors well below one grey level.
+ *   Stable (default) — fp64 cov + fp64 analytic 3x3 eigh for the stain-plane
+ *   solve (numerically robust against flips on near-degenerate spectra), with
+ *   everything else in fp32.
  *
- * On an RTX A6000 (CC 8.6, fp64:fp32 = 1:64), the mixed-precision path is
- * ~2.5–3× faster than the all-fp64 pipeline on real H&E tiles while maintaining
- * the same correctness (max|e| ≤ 2 vs torchstain).
+ *   Fast — fp32 cov + fp32 eigh for the plane solve, fp16 for large pixel
+ *   tensors (projection bmm, phi sort, reconstruct matmul), and fp32 for the
+ *   2x2 concentration solve.  No fp64 at all; ~1.2–1.3× faster on RTX A6000
+ *   while staying within the same MAE tolerance vs torchstain on synthetic H&E.
+ *
+ * Both modes share the same templated per-image reduction kernel
+ * (macenko_cov_kernel<T>) with warp-level tree reduction (no atomicAdd),
+ * the same templated closed-form 3x3 eigensolver (analytic_eigh_sym3<T>),
+ * and the same batched ATen ops for the downstream pipeline.
  */
 
 #include <torch/extension.h>
@@ -47,20 +45,23 @@ constexpr int MACENKO_THREADS = 256;
 constexpr int NUM_WARPS       = MACENKO_THREADS / 32;  // 8
 
 // ---------------------------------------------------------------------------
-// Closed-form eigendecomposition of a symmetric 3x3 matrix (double precision).
+// Closed-form eigendecomposition of a symmetric 3x3 matrix.
+// Templated on scalar type T (float or double).
 // Returns the two leading eigenvectors (columns for the middle and largest
 // eigenvalue, i.e. torch.linalg.eigh(...)[:, [1, 2]]) in `evecs2` as
 // evecs2[row][0] = middle, evecs2[row][1] = largest.
 // ---------------------------------------------------------------------------
-__device__ inline void cross3(const double a[3], const double b[3], double out[3]) {
+template <typename T>
+__device__ inline void cross3(const T a[3], const T b[3], T out[3]) {
     out[0] = a[1] * b[2] - a[2] * b[1];
     out[1] = a[2] * b[0] - a[0] * b[2];
     out[2] = a[0] * b[1] - a[1] * b[0];
 }
 
-__device__ inline void normalize3(double v[3]) {
-    const double n   = sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
-    const double inv = n > 1e-300 ? 1.0 / n : 0.0;
+template <typename T>
+__device__ inline void normalize3(T v[3]) {
+    const T n   = sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+    const T inv = n > T(1e-30) ? T(1.0) / n : T(0.0);
     v[0] *= inv;
     v[1] *= inv;
     v[2] *= inv;
@@ -68,19 +69,20 @@ __device__ inline void normalize3(double v[3]) {
 
 // Eigenvector of a symmetric matrix `M` (already A - lambda*I) as the most robust
 // cross product of its rows (largest-magnitude null-space direction).
-__device__ inline void eigvec_from_shifted(const double M[3][3], double out[3]) {
-    double r0[3] = {M[0][0], M[0][1], M[0][2]};
-    double r1[3] = {M[1][0], M[1][1], M[1][2]};
-    double r2[3] = {M[2][0], M[2][1], M[2][2]};
-    double c0[3], c1[3], c2[3];
+template <typename T>
+__device__ inline void eigvec_from_shifted(const T M[3][3], T out[3]) {
+    T r0[3] = {M[0][0], M[0][1], M[0][2]};
+    T r1[3] = {M[1][0], M[1][1], M[1][2]};
+    T r2[3] = {M[2][0], M[2][1], M[2][2]};
+    T c0[3], c1[3], c2[3];
     cross3(r0, r1, c0);
     cross3(r0, r2, c1);
     cross3(r1, r2, c2);
-    const double n0    = c0[0] * c0[0] + c0[1] * c0[1] + c0[2] * c0[2];
-    const double n1    = c1[0] * c1[0] + c1[1] * c1[1] + c1[2] * c1[2];
-    const double n2    = c2[0] * c2[0] + c2[1] * c2[1] + c2[2] * c2[2];
-    const double* best = c0;
-    double bestn       = n0;
+    const T n0    = c0[0] * c0[0] + c0[1] * c0[1] + c0[2] * c0[2];
+    const T n1    = c1[0] * c1[0] + c1[1] * c1[1] + c1[2] * c1[2];
+    const T n2    = c2[0] * c2[0] + c2[1] * c2[1] + c2[2] * c2[2];
+    const T* best = c0;
+    T bestn       = n0;
     if (n1 > bestn) {
         best  = c1;
         bestn = n1;
@@ -95,41 +97,42 @@ __device__ inline void eigvec_from_shifted(const double M[3][3], double out[3]) 
     normalize3(out);
 }
 
-__device__ void analytic_eigh_sym3(const double A[3][3], double evecs2[3][2]) {
-    const double p1 = A[0][1] * A[0][1] + A[0][2] * A[0][2] + A[1][2] * A[1][2];
-    const double q  = (A[0][0] + A[1][1] + A[2][2]) / 3.0;
+template <typename T>
+__device__ void analytic_eigh_sym3(const T A[3][3], T evecs2[3][2]) {
+    const T p1 = A[0][1] * A[0][1] + A[0][2] * A[0][2] + A[1][2] * A[1][2];
+    const T q  = (A[0][0] + A[1][1] + A[2][2]) / T(3.0);
 
-    double e_asc[3];  // eigenvalues ascending
-    if (p1 <= 1e-300) {
-        // Already diagonal.
+    T e_asc[3];  // eigenvalues ascending
+    if (p1 <= T(1e-30)) {
+        // Already diagonal (or effectively zero off-diagonal).
         e_asc[0] = e_asc[1] = e_asc[2] = q;
     } else {
-        const double p2 = (A[0][0] - q) * (A[0][0] - q) + (A[1][1] - q) * (A[1][1] - q) + (A[2][2] - q) * (A[2][2] - q) + 2.0 * p1;
-        const double p  = sqrt(p2 / 6.0);
+        const T p2 = (A[0][0] - q) * (A[0][0] - q) + (A[1][1] - q) * (A[1][1] - q) + (A[2][2] - q) * (A[2][2] - q) + T(2.0) * p1;
+        const T p  = sqrt(p2 / T(6.0));
         // B = (A - q I) / p ; r = det(B) / 2
-        double B[3][3];
+        T B[3][3];
         for (int i = 0; i < 3; ++i)
-            for (int j = 0; j < 3; ++j) B[i][j] = (A[i][j] - (i == j ? q : 0.0)) / p;
-        const double detB = B[0][0] * (B[1][1] * B[2][2] - B[1][2] * B[2][1]) - B[0][1] * (B[1][0] * B[2][2] - B[1][2] * B[2][0]) + B[0][2] * (B[1][0] * B[2][1] - B[1][1] * B[2][0]);
-        double r          = detB / 2.0;
-        if (r < -1.0) r = -1.0;
-        if (r > 1.0) r = 1.0;
-        const double phi   = acos(r) / 3.0;
-        const double e_max = q + 2.0 * p * cos(phi);
-        const double e_min = q + 2.0 * p * cos(phi + 2.0 * M_PI / 3.0);
-        const double e_mid = 3.0 * q - e_max - e_min;
-        e_asc[0]           = e_min;
-        e_asc[1]           = e_mid;
-        e_asc[2]           = e_max;
+            for (int j = 0; j < 3; ++j) B[i][j] = (A[i][j] - (i == j ? q : T(0.0))) / p;
+        const T detB = B[0][0] * (B[1][1] * B[2][2] - B[1][2] * B[2][1]) - B[0][1] * (B[1][0] * B[2][2] - B[1][2] * B[2][0]) + B[0][2] * (B[1][0] * B[2][1] - B[1][1] * B[2][0]);
+        T r          = detB / T(2.0);
+        if (r < T(-1.0)) r = T(-1.0);
+        if (r > T(1.0)) r = T(1.0);
+        const T phi   = acos(r) / T(3.0);
+        const T e_max = q + T(2.0) * p * cos(phi);
+        const T e_min = q + T(2.0) * p * cos(phi + T(2.0) * T(M_PI) / T(3.0));
+        const T e_mid = T(3.0) * q - e_max - e_min;
+        e_asc[0]      = e_min;
+        e_asc[1]      = e_mid;
+        e_asc[2]      = e_max;
     }
 
     // Eigenvectors for the two largest eigenvalues (indices 1 and 2 ascending).
     for (int col = 0; col < 2; ++col) {
-        const double lam = e_asc[col + 1];
-        double M[3][3];
+        const T lam = e_asc[col + 1];
+        T M[3][3];
         for (int i = 0; i < 3; ++i)
-            for (int j = 0; j < 3; ++j) M[i][j] = A[i][j] - (i == j ? lam : 0.0);
-        double v[3];
+            for (int j = 0; j < 3; ++j) M[i][j] = A[i][j] - (i == j ? lam : T(0.0));
+        T v[3];
         eigvec_from_shifted(M, v);
         evecs2[0][col] = v[0];
         evecs2[1][col] = v[1];
@@ -139,39 +142,40 @@ __device__ void analytic_eigh_sym3(const double A[3][3], double evecs2[3][2]) {
 
 // ---------------------------------------------------------------------------
 // Per-image filtered covariance + eigenvectors.
-// One block per image. `od_pix` is (N, P, 3) double (per-pixel OD vectors).
+// Templated on scalar type T (float for fast path, double for stable).
+// One block per image. `od_pix` is (N, P, 3) in type T (per-pixel OD vectors).
 //
 // Reduction: each thread accumulates 10 partial sums in registers over its
 // pixel stride, then a warp-level tree reduce (__shfl_down_sync) collapses
 // each warp into lane 0, which writes to shared memory.  A final single-warp
-// pass sums across the 8 warps.  This replaces the old atomicAdd-on-shared-double
-// path which used a slow CAS loop for every atomic.
+// pass sums across the 8 warps.
 //
 // Pixels with min(OD) >= beta are kept; if fewer than 3 survive, all pixels
 // are used (matches the torchstain / Torch-backend fallback). Outputs the two
-// leading eigenvectors of the covariance as `eigvecs` (N, 3, 2) double.
+// leading eigenvectors of the covariance as `eigvecs` (N, 3, 2) in type T.
 // ---------------------------------------------------------------------------
-__global__ void macenko_cov_kernel(const double* __restrict__ od_pix, int64_t P, double beta, double* __restrict__ eigvecs) {
+template <typename T>
+__global__ void macenko_cov_kernel(const T* __restrict__ od_pix, int64_t P, T beta, T* __restrict__ eigvecs) {
     constexpr int NW      = NUM_WARPS;  // 8
     constexpr int N_ACCUM = 10;
 
-    const int n       = blockIdx.x;
-    const int tid     = threadIdx.x;
-    const int lane    = tid & 31;
-    const int warp    = tid >> 5;
-    const double* img = od_pix + static_cast<int64_t>(n) * P * 3;
+    const int n    = blockIdx.x;
+    const int tid  = threadIdx.x;
+    const int lane = tid & 31;
+    const int warp = tid >> 5;
+    const T* img   = od_pix + static_cast<int64_t>(n) * P * 3;
 
     // [cnt, s0, s1, s2, xx, xy, xz, yy, yz, zz]
-    double lm[N_ACCUM] = {0};
-    double la[N_ACCUM] = {0};
+    T lm[N_ACCUM] = {0};
+    T la[N_ACCUM] = {0};
 
     // --- thread-local accumulation over pixel stride ---
     for (int64_t p = tid; p < P; p += MACENKO_THREADS) {
-        const double x0 = img[p * 3 + 0];
-        const double x1 = img[p * 3 + 1];
-        const double x2 = img[p * 3 + 2];
+        const T x0 = img[p * 3 + 0];
+        const T x1 = img[p * 3 + 1];
+        const T x2 = img[p * 3 + 2];
         // Accumulate for all-pixel fallback
-        la[0] += 1.0;
+        la[0] += T(1.0);
         la[1] += x0;
         la[2] += x1;
         la[3] += x2;
@@ -182,9 +186,9 @@ __global__ void macenko_cov_kernel(const double* __restrict__ od_pix, int64_t P,
         la[8] += x1 * x2;
         la[9] += x2 * x2;
         // Masked accumulation
-        const double mn = fmin(x0, fmin(x1, x2));
+        const T mn = fmin(x0, fmin(x1, x2));
         if (mn >= beta) {
-            lm[0] += 1.0;
+            lm[0] += T(1.0);
             lm[1] += x0;
             lm[2] += x1;
             lm[3] += x2;
@@ -200,13 +204,13 @@ __global__ void macenko_cov_kernel(const double* __restrict__ od_pix, int64_t P,
     // --- warp-level tree reduction (no atomics) ---
     // Shared memory: [NW][N_ACCUM] for masked + all, interleaved as
     //   sm[w * N_ACCUM + k], sa[w * N_ACCUM + k]
-    __shared__ double sm[NW * N_ACCUM];
-    __shared__ double sa[NW * N_ACCUM];
+    __shared__ T sm[NW * N_ACCUM];
+    __shared__ T sa[NW * N_ACCUM];
 
 #pragma unroll
     for (int k = 0; k < N_ACCUM; ++k) {
-        double vm = lm[k];
-        double va = la[k];
+        T vm = lm[k];
+        T va = la[k];
 #pragma unroll
         for (int offset = 16; offset > 0; offset >>= 1) {
             vm += __shfl_down_sync(0xffffffff, vm, offset);
@@ -221,7 +225,7 @@ __global__ void macenko_cov_kernel(const double* __restrict__ od_pix, int64_t P,
 
     // --- cross-warp reduction (first 10 threads of block) ---
     if (tid < N_ACCUM) {
-        double sum_m = 0.0, sum_a = 0.0;
+        T sum_m = T(0.0), sum_a = T(0.0);
 #pragma unroll
         for (int w = 0; w < NW; ++w) {
             sum_m += sm[w * N_ACCUM + tid];
@@ -235,44 +239,44 @@ __global__ void macenko_cov_kernel(const double* __restrict__ od_pix, int64_t P,
     // --- thread 0: covariance + eigh ---
     if (tid == 0) {
         // Choose masked accumulators unless too few pixels survived the OD filter.
-        const double* acc = (sm[0] >= 3.0) ? sm : sa;
-        const double cnt  = acc[0];
-        double cov[3][3];
-        if (cnt > 1.0) {
-            const double inv   = 1.0 / cnt;
-            const double mean0 = acc[1] * inv, mean1 = acc[2] * inv, mean2 = acc[3] * inv;
-            const double denom = cnt - 1.0;
-            cov[0][0]          = (acc[4] - acc[1] * mean0) / denom;
-            cov[0][1]          = (acc[5] - acc[1] * mean1) / denom;
-            cov[0][2]          = (acc[6] - acc[1] * mean2) / denom;
-            cov[1][1]          = (acc[7] - acc[2] * mean1) / denom;
-            cov[1][2]          = (acc[8] - acc[2] * mean2) / denom;
-            cov[2][2]          = (acc[9] - acc[3] * mean2) / denom;
-            cov[1][0]          = cov[0][1];
-            cov[2][0]          = cov[0][2];
-            cov[2][1]          = cov[1][2];
+        const T* acc = (sm[0] >= T(3.0)) ? sm : sa;
+        const T cnt  = acc[0];
+        T cov[3][3];
+        if (cnt > T(1.0)) {
+            const T inv   = T(1.0) / cnt;
+            const T mean0 = acc[1] * inv, mean1 = acc[2] * inv, mean2 = acc[3] * inv;
+            const T denom = cnt - T(1.0);
+            cov[0][0]     = (acc[4] - acc[1] * mean0) / denom;
+            cov[0][1]     = (acc[5] - acc[1] * mean1) / denom;
+            cov[0][2]     = (acc[6] - acc[1] * mean2) / denom;
+            cov[1][1]     = (acc[7] - acc[2] * mean1) / denom;
+            cov[1][2]     = (acc[8] - acc[2] * mean2) / denom;
+            cov[2][2]     = (acc[9] - acc[3] * mean2) / denom;
+            cov[1][0]     = cov[0][1];
+            cov[2][0]     = cov[0][2];
+            cov[2][1]     = cov[1][2];
         } else {
 #pragma unroll
             for (int i = 0; i < 3; ++i)
 #pragma unroll
-                for (int j = 0; j < 3; ++j) cov[i][j] = 0.0;
+                for (int j = 0; j < 3; ++j) cov[i][j] = T(0.0);
         }
-        double evecs2[3][2];
+        T evecs2[3][2];
         analytic_eigh_sym3(cov, evecs2);
-        double* out = eigvecs + static_cast<int64_t>(n) * 6;
-        out[0]      = evecs2[0][0];
-        out[1]      = evecs2[0][1];
-        out[2]      = evecs2[1][0];
-        out[3]      = evecs2[1][1];
-        out[4]      = evecs2[2][0];
-        out[5]      = evecs2[2][1];
+        T* out = eigvecs + static_cast<int64_t>(n) * 6;
+        out[0] = evecs2[0][0];
+        out[1] = evecs2[0][1];
+        out[2] = evecs2[1][0];
+        out[3] = evecs2[1][1];
+        out[4] = evecs2[2][0];
+        out[5] = evecs2[2][1];
     }
 }
 
 // Nearest-rank percentile (matches torchstain: k = 1 + round(.01*q*(n-1)),
 // 0-based index = round(.01*q*(n-1))) over sorted rows, per image.
-// Works with fp32 or fp64 sorted_asc and counts (counts must be same dtype as
-// sorted_asc for the arithmetic to stay in the same precision).
+// Works with any dtype for sorted_asc and counts (index arithmetic is always
+// done in fp64 internally, so counts dtype does not need to match sorted_asc).
 torch::Tensor gather_percentile(const torch::Tensor& sorted_asc, const torch::Tensor& counts, double q) {
     // counts and sorted_asc may be fp32 or fp64; do arithmetic in float64 for
     // the index computation to match torchstain's exact formula regardless of
@@ -283,7 +287,12 @@ torch::Tensor gather_percentile(const torch::Tensor& sorted_asc, const torch::Te
 
 }  // namespace
 
-torch::Tensor macenko_cuda(torch::Tensor input_images, torch::Tensor stain_matrix, torch::Tensor target_max_conc) {
+// ---------------------------------------------------------------------------
+// Shared Macenko pipeline with two precision modes:
+//   Stable — fp64 cov + eigh, fp32 downstream.
+//   Fast   — fp32 cov + eigh, fp16 large pixels, fp32 2×2 solve.
+// ---------------------------------------------------------------------------
+static torch::Tensor macenko_cuda_impl(torch::Tensor input_images, torch::Tensor stain_matrix, torch::Tensor target_max_conc, bool fast) {
     TORCH_CHECK(input_images.is_cuda(), "input_images must be a CUDA tensor");
     TORCH_CHECK(stain_matrix.is_cuda(), "stain_matrix must be a CUDA tensor");
     TORCH_CHECK(target_max_conc.is_cuda(), "target_max_conc must be a CUDA tensor");
@@ -312,91 +321,182 @@ torch::Tensor macenko_cuda(torch::Tensor input_images, torch::Tensor stain_matri
     constexpr float beta_f = 0.15f;
 
     auto f32 = images_float.options().dtype(torch::kFloat32);
-    auto f64 = f32.dtype(torch::kFloat64);
 
     // ---- fp32 optical density (keeps all intermediates small/fast) ----------
     // OD in fp32 for downstream: projection, phi, concentrations, reconstruct.
     auto od_all = -torch::log((images_float * 255.0f + 1.0f) / Io_f).reshape({N, 3, P});
     auto od_pix = od_all.permute({0, 2, 1}).contiguous();  // (N, P, 3) fp32
 
-    // Cast only what the cov kernel needs to fp64.
-    auto od_pix_f64 = od_pix.to(torch::kFloat64);  // (N, P, 3) fp64
-
-    // ---- fp64 covariance + analytic eigh (the numerically sensitive part) ---
-    auto eigvecs_f64    = torch::empty({N, 3, 2}, f64);
     cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-    macenko_cov_kernel<<<static_cast<unsigned int>(N), MACENKO_THREADS, 0, stream>>>(od_pix_f64.data_ptr<double>(), P, beta, eigvecs_f64.data_ptr<double>());
-    cudaError_t err = cudaGetLastError();
-    TORCH_CHECK(err == cudaSuccess, "CUDA error in macenko_cov_kernel: ", cudaGetErrorString(err));
 
-    // ---- fp32 downstream: projection → phi → HE → concentrations → RGB -----
-    auto eigvecs = eigvecs_f64.to(torch::kFloat32);  // (N, 3, 2) fp32
+    // Pre-compute OD mask from fp32 od_pix (before any fp16 conversion).
+    auto od_min_f32 = std::get<0>(od_pix.min(/*dim=*/2));       // (N, P) fp32
+    auto mask       = od_min_f32 >= beta_f;                     // (N, P) bool
+    auto cnt        = mask.sum(/*dim=*/1).to(torch::kFloat32);  // (N,) fp32
+    auto use_all    = cnt < 3.0f;                               // (N,) bool
+    auto eff_mask   = mask.logical_or(use_all.unsqueeze(1));    // (N, P) bool
+    auto cnt_eff    = torch::where(use_all, torch::full_like(cnt, static_cast<float>(P)), cnt);
 
-    // Projection onto the stain plane (fp32 bmm: ~20× faster than fp64 on consumer GPUs).
-    auto That = torch::bmm(od_pix, eigvecs);                                                         // (N, P, 2) fp32
-    auto phi  = torch::atan2(That.index({Slice(), Slice(), 1}), That.index({Slice(), Slice(), 0}));  // (N, P) fp32
+    torch::Tensor eigvecs;  // (N, 3, 2) — always fp32 output
+    torch::Tensor min_phi, max_phi, HE;
+    torch::Tensor C0, C1, maxC0, maxC1, od_recon;
 
-    // Mask: pixels with min(OD) >= beta (fp32).
-    auto od_min   = std::get<0>(od_pix.min(/*dim=*/2));       // (N, P) fp32
-    auto mask     = od_min >= beta_f;                         // (N, P) bool
-    auto cnt      = mask.sum(/*dim=*/1).to(torch::kFloat32);  // (N,) fp32
-    auto use_all  = cnt < 3.0f;                               // (N,) bool
-    auto eff_mask = mask.logical_or(use_all.unsqueeze(1));    // (N, P) bool
-    auto cnt_eff  = torch::where(use_all, torch::full_like(cnt, static_cast<float>(P)), cnt);
+    if (fast) {
+        // =====================================================================
+        // FAST PATH: fp32 cov/eigh + fp16 large pixels + fp32 2×2 solve.
+        // No fp64 anywhere in this path.
+        // =====================================================================
 
-    // Percentiles of phi (fp32 sort).
-    const float INF = std::numeric_limits<float>::infinity();
-    auto phi_masked = torch::where(eff_mask, phi, torch::full_like(phi, INF));
-    auto phi_sorted = std::get<0>(torch::sort(phi_masked, /*dim=*/1, /*descending=*/false));
-    auto min_phi    = gather_percentile(phi_sorted, cnt_eff, alpha);          // (N, 1)
-    auto max_phi    = gather_percentile(phi_sorted, cnt_eff, 100.0 - alpha);  // (N, 1)
+        // ---- fp32 covariance + analytic eigh --------------------------------
+        eigvecs = torch::empty({N, 3, 2}, f32);
+        macenko_cov_kernel<float><<<static_cast<unsigned int>(N), MACENKO_THREADS, 0, stream>>>(od_pix.data_ptr<float>(), P, static_cast<float>(beta), eigvecs.data_ptr<float>());
+        cudaError_t err = cudaGetLastError();
+        TORCH_CHECK(err == cudaSuccess, "CUDA error in macenko_cov_kernel<float>: ", cudaGetErrorString(err));
 
-    // Extreme stain vectors from angular bounds.
-    auto angle_min = torch::cat({torch::cos(min_phi), torch::sin(min_phi)}, /*dim=*/1).unsqueeze(2);  // (N, 2, 1)
-    auto angle_max = torch::cat({torch::cos(max_phi), torch::sin(max_phi)}, /*dim=*/1).unsqueeze(2);  // (N, 2, 1)
-    auto vMin      = torch::bmm(eigvecs, angle_min);                                                  // (N, 3, 1)
-    auto vMax      = torch::bmm(eigvecs, angle_max);                                                  // (N, 3, 1)
+        // --- Projection onto the stain plane (fp16 bmm → Tensor Cores) -------
+        auto od_pix_f16  = od_pix.to(torch::kFloat16);           // (N, P, 3)
+        auto eigvecs_f16 = eigvecs.to(torch::kFloat16);          // (N, 3, 2)
+        auto That_f16    = torch::bmm(od_pix_f16, eigvecs_f16);  // (N, P, 2) fp16
 
-    // H/E ordering heuristic: hematoxylin vector (larger red-channel OD) first.
-    auto he_first_min = (vMin.index({Slice(), 0, 0}) > vMax.index({Slice(), 0, 0})).view({N, 1, 1});
-    auto HE_min_first = torch::cat({vMin, vMax}, /*dim=*/2);  // (N, 3, 2)
-    auto HE_max_first = torch::cat({vMax, vMin}, /*dim=*/2);
-    auto HE           = torch::where(he_first_min, HE_min_first, HE_max_first);  // (N, 3, 2)
+        // --- phi, mask, percentiles (fp16) -----------------------------------
+        auto phi_f16 = torch::atan2(That_f16.index({Slice(), Slice(), 1}), That_f16.index({Slice(), Slice(), 0}));  // (N, P) fp16
 
-    // ---- concentrations via 2×2 normal equations (fp32) ----------------------
-    auto HEt = HE.transpose(1, 2);       // (N, 2, 3)
-    auto A2  = torch::bmm(HEt, HE);      // (N, 2, 2) symmetric
-    auto rhs = torch::bmm(HEt, od_all);  // (N, 2, P)
-    auto a   = A2.index({Slice(), 0, 0});
-    auto b   = A2.index({Slice(), 0, 1});
-    auto c_  = A2.index({Slice(), 1, 1});
-    auto det = (a * c_ - b * b).view({N, 1, 1});
-    // inv = 1/det * [[c, -b], [-b, a]]
-    auto inv00 = (c_ / det.view({N})).view({N, 1});
-    auto inv01 = (-b / det.view({N})).view({N, 1});
-    auto inv11 = (a / det.view({N})).view({N, 1});
-    auto rhs0  = rhs.index({Slice(), 0, Slice()});  // (N, P)
-    auto rhs1  = rhs.index({Slice(), 1, Slice()});  // (N, P)
-    auto C0    = inv00 * rhs0 + inv01 * rhs1;       // (N, P)
-    auto C1    = inv01 * rhs0 + inv11 * rhs1;       // (N, P)
+        const float INF_F16 = 65504.0f;  // fp16 max representable
+        auto phi_masked_f16 = torch::where(eff_mask, phi_f16, torch::full_like(phi_f16, INF_F16));
+        auto phi_sorted_f16 = std::get<0>(torch::sort(phi_masked_f16, /*dim=*/1, /*descending=*/false));
+        // gather_percentile does fp64 index math; gather works on any dtype.
+        min_phi = gather_percentile(phi_sorted_f16, cnt_eff, alpha).to(torch::kFloat32);          // (N, 1) fp32
+        max_phi = gather_percentile(phi_sorted_f16, cnt_eff, 100.0 - alpha).to(torch::kFloat32);  // (N, 1) fp32
 
-    // 99th percentile of each concentration (fp32 sort).
-    auto cnt_all   = torch::full({N}, static_cast<float>(P), f32);
-    auto C0_sorted = std::get<0>(torch::sort(C0, /*dim=*/1));
-    auto C1_sorted = std::get<0>(torch::sort(C1, /*dim=*/1));
-    auto maxC0     = gather_percentile(C0_sorted, cnt_all, 99.0);  // (N, 1)
-    auto maxC1     = gather_percentile(C1_sorted, cnt_all, 99.0);  // (N, 1)
+        // --- Extreme stain vectors (small fp32 bmm — not worth fp16) ---------
+        auto angle_min = torch::cat({torch::cos(min_phi), torch::sin(min_phi)}, /*dim=*/1).unsqueeze(2);
+        auto angle_max = torch::cat({torch::cos(max_phi), torch::sin(max_phi)}, /*dim=*/1).unsqueeze(2);
+        auto vMin      = torch::bmm(eigvecs, angle_min);
+        auto vMax      = torch::bmm(eigvecs, angle_max);
 
-    // ---- normalise concentrations to the reference and reconstruct -----------
-    auto tmc = target_max_conc.flatten().to(torch::kFloat32);
-    TORCH_CHECK(tmc.size(0) == 2, "target_max_conc must have 2 elements");
-    auto scale0 = (tmc.index({0}) / maxC0);                             // (N, 1)
-    auto scale1 = (tmc.index({1}) / maxC1);                             // (N, 1)
-    auto Cn     = torch::stack({C0 * scale0, C1 * scale1}, /*dim=*/1);  // (N, 2, P)
+        // --- H/E ordering heuristic ------------------------------------------
+        auto he_first_min = (vMin.index({Slice(), 0, 0}) > vMax.index({Slice(), 0, 0})).view({N, 1, 1});
+        auto HE_min_first = torch::cat({vMin, vMax}, /*dim=*/2);
+        auto HE_max_first = torch::cat({vMax, vMin}, /*dim=*/2);
+        HE                = torch::where(he_first_min, HE_min_first, HE_max_first);  // (N, 3, 2) fp32
 
-    auto stain    = stain_matrix.to(torch::kFloat32);  // (3, 2)
-    auto od_recon = torch::matmul(stain, Cn);          // (N, 3, P)
-    auto rgb      = torch::clamp(Io_f * torch::exp(-od_recon), 0.0f, 255.0f).reshape({N, 3, H, W});
+        // --- concentrations: fp32 rhs (sensitive) + fp32 2×2 solve -----------
+        // rhs → C → percentile is numerically sensitive; keep fp32 here.
+        auto HEt = HE.transpose(1, 2);       // (N, 2, 3) fp32
+        auto A2  = torch::bmm(HEt, HE);      // (N, 2, 2) fp32 — tiny
+        auto rhs = torch::bmm(HEt, od_all);  // (N, 2, P) fp32
 
+        auto a     = A2.index({Slice(), 0, 0});
+        auto b     = A2.index({Slice(), 0, 1});
+        auto c_    = A2.index({Slice(), 1, 1});
+        auto det   = (a * c_ - b * b).view({N, 1, 1});
+        auto inv00 = (c_ / det.view({N})).view({N, 1});  // fp32
+        auto inv01 = (-b / det.view({N})).view({N, 1});  // fp32
+        auto inv11 = (a / det.view({N})).view({N, 1});   // fp32
+        auto rhs0  = rhs.index({Slice(), 0, Slice()});   // (N, P) fp32
+        auto rhs1  = rhs.index({Slice(), 1, Slice()});   // (N, P) fp32
+        C0         = inv00 * rhs0 + inv01 * rhs1;        // (N, P) fp32
+        C1         = inv01 * rhs0 + inv11 * rhs1;        // (N, P) fp32
+
+        // --- 99th percentile of concentrations (fp16 sort) --------------------
+        auto cnt_all_f32   = torch::full({N}, static_cast<float>(P), f32);
+        auto C0_f16        = C0.to(torch::kFloat16);
+        auto C1_f16        = C1.to(torch::kFloat16);
+        auto C0_sorted_f16 = std::get<0>(torch::sort(C0_f16, /*dim=*/1));
+        auto C1_sorted_f16 = std::get<0>(torch::sort(C1_f16, /*dim=*/1));
+        maxC0              = gather_percentile(C0_sorted_f16, cnt_all_f32, 99.0).to(torch::kFloat32);  // (N, 1) fp32
+        maxC1              = gather_percentile(C1_sorted_f16, cnt_all_f32, 99.0).to(torch::kFloat32);  // (N, 1) fp32
+
+        // --- normalise and reconstruct (fp16 matmul → safe) -------------------
+        auto tmc = target_max_conc.flatten().to(torch::kFloat32);
+        TORCH_CHECK(tmc.size(0) == 2, "target_max_conc must have 2 elements");
+        auto scale0        = (tmc.index({0}) / maxC0);                                 // (N, 1) fp32
+        auto scale1        = (tmc.index({1}) / maxC1);                                 // (N, 1) fp32
+        auto C0_scaled_f16 = (C0_f16 * scale0.to(torch::kFloat16));                    // (N, P) fp16
+        auto C1_scaled_f16 = (C1_f16 * scale1.to(torch::kFloat16));                    // (N, P) fp16
+        auto Cn_f16        = torch::stack({C0_scaled_f16, C1_scaled_f16}, /*dim=*/1);  // (N, 2, P) fp16
+        auto stain_f16     = stain_matrix.to(torch::kFloat16);                         // (3, 2) fp16
+        od_recon           = torch::matmul(stain_f16, Cn_f16).to(torch::kFloat32);     // (N, 3, P) fp32
+
+    } else {
+        // =====================================================================
+        // STABLE PATH: fp64 cov + fp64 eigh, fp32 downstream.
+        // =====================================================================
+        auto f64 = f32.dtype(torch::kFloat64);
+
+        // ---- fp64 covariance + analytic eigh --------------------------------
+        auto od_pix_f64  = od_pix.to(torch::kFloat64);  // (N, P, 3) fp64
+        auto eigvecs_f64 = torch::empty({N, 3, 2}, f64);
+        macenko_cov_kernel<double><<<static_cast<unsigned int>(N), MACENKO_THREADS, 0, stream>>>(od_pix_f64.data_ptr<double>(), P, beta, eigvecs_f64.data_ptr<double>());
+        cudaError_t err = cudaGetLastError();
+        TORCH_CHECK(err == cudaSuccess, "CUDA error in macenko_cov_kernel<double>: ", cudaGetErrorString(err));
+        eigvecs = eigvecs_f64.to(torch::kFloat32);  // (N, 3, 2) fp32
+
+        // Projection onto the stain plane.
+        auto That  = torch::bmm(od_pix, eigvecs);  // (N, P, 2) fp32
+        auto phi_s = torch::atan2(That.index({Slice(), Slice(), 1}), That.index({Slice(), Slice(), 0}));
+
+        // Percentiles of phi (fp32 sort).
+        const float INF = std::numeric_limits<float>::infinity();
+        auto phi_masked = torch::where(eff_mask, phi_s, torch::full_like(phi_s, INF));
+        auto phi_sorted = std::get<0>(torch::sort(phi_masked, /*dim=*/1, /*descending=*/false));
+        min_phi         = gather_percentile(phi_sorted, cnt_eff, alpha);
+        max_phi         = gather_percentile(phi_sorted, cnt_eff, 100.0 - alpha);
+
+        // Extreme stain vectors from angular bounds.
+        auto angle_min = torch::cat({torch::cos(min_phi), torch::sin(min_phi)}, /*dim=*/1).unsqueeze(2);
+        auto angle_max = torch::cat({torch::cos(max_phi), torch::sin(max_phi)}, /*dim=*/1).unsqueeze(2);
+        auto vMin      = torch::bmm(eigvecs, angle_min);
+        auto vMax      = torch::bmm(eigvecs, angle_max);
+
+        // H/E ordering heuristic.
+        auto he_first_min = (vMin.index({Slice(), 0, 0}) > vMax.index({Slice(), 0, 0})).view({N, 1, 1});
+        auto HE_min_first = torch::cat({vMin, vMax}, /*dim=*/2);
+        auto HE_max_first = torch::cat({vMax, vMin}, /*dim=*/2);
+        HE                = torch::where(he_first_min, HE_min_first, HE_max_first);
+
+        // Concentrations: 2×2 normal equations.
+        auto HEt   = HE.transpose(1, 2);
+        auto A2    = torch::bmm(HEt, HE);
+        auto rhs   = torch::bmm(HEt, od_all);
+        auto a     = A2.index({Slice(), 0, 0});
+        auto b     = A2.index({Slice(), 0, 1});
+        auto c_    = A2.index({Slice(), 1, 1});
+        auto det   = (a * c_ - b * b).view({N, 1, 1});
+        auto inv00 = (c_ / det.view({N})).view({N, 1});
+        auto inv01 = (-b / det.view({N})).view({N, 1});
+        auto inv11 = (a / det.view({N})).view({N, 1});
+        auto rhs0  = rhs.index({Slice(), 0, Slice()});
+        auto rhs1  = rhs.index({Slice(), 1, Slice()});
+        C0         = inv00 * rhs0 + inv01 * rhs1;
+        C1         = inv01 * rhs0 + inv11 * rhs1;
+
+        // 99th percentile of each concentration.
+        auto cnt_all   = torch::full({N}, static_cast<float>(P), f32);
+        auto C0_sorted = std::get<0>(torch::sort(C0, /*dim=*/1));
+        auto C1_sorted = std::get<0>(torch::sort(C1, /*dim=*/1));
+        maxC0          = gather_percentile(C0_sorted, cnt_all, 99.0);
+        maxC1          = gather_percentile(C1_sorted, cnt_all, 99.0);
+
+        // Normalise and reconstruct.
+        auto tmc = target_max_conc.flatten().to(torch::kFloat32);
+        TORCH_CHECK(tmc.size(0) == 2, "target_max_conc must have 2 elements");
+        auto scale0 = (tmc.index({0}) / maxC0);
+        auto scale1 = (tmc.index({1}) / maxC1);
+        auto Cn     = torch::stack({C0 * scale0, C1 * scale1}, /*dim=*/1);
+        auto stain  = stain_matrix.to(torch::kFloat32);
+        od_recon    = torch::matmul(stain, Cn);
+    }
+
+    // ---- final clamp + reshape (fp32, shared by both paths) -----------------
+    auto rgb = torch::clamp(Io_f * torch::exp(-od_recon), 0.0f, 255.0f).reshape({N, 3, H, W});
     return rgb.to(input_images.scalar_type());
+}
+
+torch::Tensor macenko_cuda(torch::Tensor input_images, torch::Tensor stain_matrix, torch::Tensor target_max_conc) {
+    return macenko_cuda_impl(input_images, stain_matrix, target_max_conc, /*fast=*/false);
+}
+
+torch::Tensor macenko_cuda_fast(torch::Tensor input_images, torch::Tensor stain_matrix, torch::Tensor target_max_conc) {
+    return macenko_cuda_impl(input_images, stain_matrix, target_max_conc, /*fast=*/true);
 }

--- a/tests/torch_interface/test_correctness_against_references.py
+++ b/tests/torch_interface/test_correctness_against_references.py
@@ -159,8 +159,8 @@ class TestAgainstBaselines:
         if baseline_tensor.max().item() > 240.0:
             assert result.max().item() > 240.0, f"Macenko incorrectly capped at Io (backend={backend}, precision={precision}, hw={image_hw})"
 
-    def test_macenko_stable_fast_not_identical(self, image_hw):
-        """Fast and stable must produce different results (fp16 rounding)."""
+    def test_macenko_stable_and_fast_both_correct(self, image_hw):
+        """Stable and fast paths both match torchstain; precision wiring is intact."""
         if not torch.cuda.is_available() or not TORCH_CUDA_AVAILABLE:
             pytest.skip("torch_cuda extension unavailable")
         cuda_device = torch.device("cuda")
@@ -181,6 +181,9 @@ class TestAgainstBaselines:
         normalizer_fast._is_fitted = True
         result_fast = normalizer_fast.transform(source_image)
 
+        assert normalizer_stable._precision == "stable"
+        assert normalizer_fast._precision == "fast"
+
         # Both must pass correctness.
         ref_chw = reference_image.squeeze(0).cpu()
         src_chw = source_image.squeeze(0).cpu()
@@ -194,10 +197,6 @@ class TestAgainstBaselines:
             mae = (r - baseline_tensor).abs().mean().item()
             assert torch.allclose(r, baseline_tensor, rtol=RTOL, atol=MACENKO_ATOL), f"{label} mismatch (hw={image_hw})"
             assert mae <= MACENKO_MAE, f"{label} MAE {mae:.4f} (hw={image_hw})"
-
-        # Fast must differ from stable (fp16 rounding guarantees this on >= 256² tiles).
-        if image_hw[0] >= 128 and image_hw[1] >= 128:
-            assert not torch.equal(result_stable, result_fast), f"fast and stable results are bitwise identical — fast path may not be using fp16 (hw={image_hw})"
 
     def test_macenko_precision_validation(self):
         """Precision validation and backend compatibility checks."""

--- a/tests/torch_interface/test_correctness_against_references.py
+++ b/tests/torch_interface/test_correctness_against_references.py
@@ -126,8 +126,12 @@ class TestAgainstBaselines:
 
         assert torch.allclose(result, baseline_tensor, rtol=RTOL, atol=ATOL), f"Reinhard mismatch vs torchstain (backend={backend}, hw={image_hw})"
 
-    def test_macenko_vs_torchstain(self, device, backend, image_hw):
+    @pytest.mark.parametrize("precision", ["stable", "fast"])
+    def test_macenko_vs_torchstain(self, device, backend, image_hw, precision):
         # Synthetic Beer-Lambert H&E: Macenko needs a well-defined stain plane (see module note).
+        if precision == "fast" and backend != "torch_cuda":
+            pytest.skip("fast precision only applies to torch_cuda backend")
+
         reference_image, source_image = _macenko_pair(image_hw, device)
         ref_chw = reference_image.squeeze(0).cpu()
         src_chw = source_image.squeeze(0).cpu()
@@ -140,7 +144,7 @@ class TestAgainstBaselines:
         fit_normalizer = Macenko(device=torch.device("cpu"), backend="torch")
         fit_normalizer.fit(reference_image.cpu())
 
-        normalizer = Macenko(device=device, backend=backend)
+        normalizer = Macenko(device=device, backend=backend, precision=precision)
         normalizer._stain_matrix = fit_normalizer._stain_matrix.to(device)
         normalizer._target_max_conc = fit_normalizer._target_max_conc.to(device)
         normalizer._is_fitted = True
@@ -148,12 +152,66 @@ class TestAgainstBaselines:
 
         assert torch.allclose(fit_normalizer._stain_matrix.cpu().float(), baseline.HERef.float(), rtol=1e-4, atol=1e-5), f"Macenko HE mismatch (backend={backend}, hw={image_hw})"
         assert torch.allclose(fit_normalizer._target_max_conc.cpu().float().flatten(), baseline.maxCRef.float().flatten(), rtol=1e-3, atol=1e-4), f"Macenko maxC mismatch (backend={backend}, hw={image_hw})"
-        assert torch.allclose(result, baseline_tensor, rtol=RTOL, atol=MACENKO_ATOL), f"Macenko mismatch vs torchstain (backend={backend}, hw={image_hw})"
+        assert torch.allclose(result, baseline_tensor, rtol=RTOL, atol=MACENKO_ATOL), f"Macenko mismatch vs torchstain (backend={backend}, precision={precision}, hw={image_hw})"
         mae = (result - baseline_tensor).abs().mean().item()
-        assert mae <= MACENKO_MAE, f"Macenko MAE {mae:.4f} > {MACENKO_MAE} (backend={backend}, hw={image_hw})"
+        assert mae <= MACENKO_MAE, f"Macenko MAE {mae:.4f} > {MACENKO_MAE} (backend={backend}, precision={precision}, hw={image_hw})"
         assert result.max().item() <= 255.0 + MACENKO_ATOL
         if baseline_tensor.max().item() > 240.0:
-            assert result.max().item() > 240.0, f"Macenko incorrectly capped at Io (backend={backend}, hw={image_hw})"
+            assert result.max().item() > 240.0, f"Macenko incorrectly capped at Io (backend={backend}, precision={precision}, hw={image_hw})"
+
+    def test_macenko_stable_fast_not_identical(self, image_hw):
+        """Fast and stable must produce different results (fp16 rounding)."""
+        if not torch.cuda.is_available() or not TORCH_CUDA_AVAILABLE:
+            pytest.skip("torch_cuda extension unavailable")
+        cuda_device = torch.device("cuda")
+        reference_image, source_image = _macenko_pair(image_hw, cuda_device)
+
+        fit_normalizer = Macenko(device=torch.device("cpu"), backend="torch")
+        fit_normalizer.fit(reference_image.cpu())
+
+        normalizer_stable = Macenko(device=cuda_device, backend="torch_cuda", precision="stable")
+        normalizer_stable._stain_matrix = fit_normalizer._stain_matrix.to(cuda_device)
+        normalizer_stable._target_max_conc = fit_normalizer._target_max_conc.to(cuda_device)
+        normalizer_stable._is_fitted = True
+        result_stable = normalizer_stable.transform(source_image)
+
+        normalizer_fast = Macenko(device=cuda_device, backend="torch_cuda", precision="fast")
+        normalizer_fast._stain_matrix = fit_normalizer._stain_matrix.to(cuda_device)
+        normalizer_fast._target_max_conc = fit_normalizer._target_max_conc.to(cuda_device)
+        normalizer_fast._is_fitted = True
+        result_fast = normalizer_fast.transform(source_image)
+
+        # Both must pass correctness.
+        ref_chw = reference_image.squeeze(0).cpu()
+        src_chw = source_image.squeeze(0).cpu()
+        baseline = TorchMacenkoNormalizer()
+        baseline.fit(ref_chw)
+        baseline_rgb, _, _ = baseline.normalize(src_chw, stains=True)
+        baseline_tensor = baseline_rgb.permute(2, 0, 1).float()
+
+        for label, res in [("stable", result_stable), ("fast", result_fast)]:
+            r = res.squeeze(0).cpu().float()
+            mae = (r - baseline_tensor).abs().mean().item()
+            assert torch.allclose(r, baseline_tensor, rtol=RTOL, atol=MACENKO_ATOL), f"{label} mismatch (hw={image_hw})"
+            assert mae <= MACENKO_MAE, f"{label} MAE {mae:.4f} (hw={image_hw})"
+
+        # Fast must differ from stable (fp16 rounding guarantees this on >= 256² tiles).
+        if image_hw[0] >= 128 and image_hw[1] >= 128:
+            assert not torch.equal(result_stable, result_fast), f"fast and stable results are bitwise identical — fast path may not be using fp16 (hw={image_hw})"
+
+    def test_macenko_precision_validation(self):
+        """Precision validation and backend compatibility checks."""
+        with pytest.raises(ValueError, match="precision='fast' requires backend='torch_cuda'"):
+            Macenko(backend="torch", precision="fast")
+
+        # precision='fast' with auto-selected torch backend (no CUDA) should also raise.
+        if not torch.cuda.is_available():
+            with pytest.raises(ValueError, match="precision='fast' requires backend='torch_cuda'"):
+                Macenko(precision="fast")
+
+        # Invalid precision value.
+        with pytest.raises(ValueError, match="precision must be"):
+            Macenko(precision="ultra")
 
     @pytest.mark.parametrize("channel_axis", [1, -1, 3, -3])
     def test_histogram_matching_vs_skimage(self, reference_image, source_image, device, backend, channel_axis, image_hw):


### PR DESCRIPTION
## Summary
- Add Macenko `"fast"` precision mode on the torch CUDA path
- Update CUDA kernels / bindings and correctness tests
- Refresh Pareto time vs MAE benchmark
## Test plan
- [ ] `make fix` / lint clean
- [ ] Correctness tests vs torchstain pass
- [ ] Pareto benchmark script runs and plot looks sane