### PR TITLE
fix: remove accidental manuscript gitlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ src/stainx_cuda/*.so
 # Local-only tooling (not part of the package)
 scripts/sentrux_score.py
 
+manuscript/


### PR DESCRIPTION
## Summary
- Remove the `manuscript` gitlink that was accidentally committed in the logo PR
- Add `manuscript/` to `.gitignore` so it stays local-only

## Test plan
- [x] Confirm `manuscript` is no longer tracked after merge
- [x] Local `manuscript/` directory preserved on developer machines

Made with [Cursor](https://cursor.com)