### PR TITLE
fix: loosen Macenko transform allclose atol for Windows

### DIFF
--- a/tests/torch_interface/test_stain_normalizer_transform.py
+++ b/tests/torch_interface/test_stain_normalizer_transform.py
@@ -133,7 +133,8 @@ class TestStainNormalizerTransform:
         t = StainNormalizerTransform(method="macenko", mode="reference", reference=ref, device="cpu")
         n = Macenko(device="cpu", normalize_to_0_1=True)
         n.fit(ref)
-        assert torch.allclose(t(src), n.transform(src), rtol=0, atol=1e-5)
+        # Independent fits + platform BLAS (esp. Windows) can differ by ~1e-5..1e-4
+        assert torch.allclose(t(src), n.transform(src), rtol=0, atol=1e-4)
 
     def test_prebuilt_normalize_flag_can_clear(self, reference):
         n = Macenko(device="cpu", normalize_to_0_1=True)


### PR DESCRIPTION
## Summary
- `test_normalize_to_0_1_matches_explicit_macenko` failed on Windows with `atol=1e-5` after Lint started passing again (independent Macenko fits + platform BLAS noise).
- Loosen to `atol=1e-4` (Linux worst-case over 50 seeds is ~7e-5).

## Test plan
- [x] Local pytest for the failing test
- [ ] Windows 3.11 / 3.12 CI green